### PR TITLE
making it work

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,8 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.wazo.callkeep">
-
-    <uses-permission android:name="android.permission.CALL_PHONE" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE"
-                     android:maxSdkVersion="29" />
-    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
 </manifest>

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -93,11 +93,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     private static final String E_ACTIVITY_DOES_NOT_EXIST = "E_ACTIVITY_DOES_NOT_EXIST";
     private static final String REACT_NATIVE_MODULE_NAME = "RNCallKeep";
-    private static final String[] permissions = {
-        Build.VERSION.SDK_INT < 30 ? Manifest.permission.READ_PHONE_STATE : Manifest.permission.READ_PHONE_NUMBERS,
-        Manifest.permission.CALL_PHONE,
-        Manifest.permission.RECORD_AUDIO
-    };
+    private static final String[] permissions = {};
 
     private static final String TAG = "RNCK:RNCallKeepModule";
     private static TelecomManager telecomManager;
@@ -575,7 +571,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         String appName = this.getApplicationName(this.getAppContext());
 
         PhoneAccount.Builder builder = new PhoneAccount.Builder(handle, appName)
-                .setCapabilities(PhoneAccount.CAPABILITY_CALL_PROVIDER);
+                .setCapabilities(PhoneAccount.CAPABILITY_SELF_MANAGED);
 
         if (_settings != null && _settings.hasKey("imageName")) {
             int identifier = appContext.getResources().getIdentifier(_settings.getString("imageName"), "drawable", appContext.getPackageName());

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -83,12 +83,14 @@ public class VoiceConnection extends Connection {
 
     @Override
     public void onCallAudioStateChanged(CallAudioState state) {
-        if (state.isMuted() == this.isMuted) {
-            return;
-        }
+        /*
+            if (state.isMuted() == this.isMuted) {
+                return;
+            }
 
-        this.isMuted = state.isMuted();
-        sendCallRequestToActivity(isMuted ? ACTION_MUTE_CALL : ACTION_UNMUTE_CALL, handle);
+            this.isMuted = state.isMuted();
+            sendCallRequestToActivity(isMuted ? ACTION_MUTE_CALL : ACTION_UNMUTE_CALL, handle);
+         */
     }
 
     @Override

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -304,6 +304,15 @@ public class VoiceConnectionService extends ConnectionService {
         extrasMap.put(EXTRA_CALL_NUMBER, request.getAddress().toString());
         VoiceConnection connection = new VoiceConnection(this, extrasMap);
         connection.setConnectionCapabilities(Connection.CAPABILITY_MUTE | Connection.CAPABILITY_SUPPORT_HOLD);
+
+        Context context = getApplicationContext();
+        TelecomManager telecomManager = (TelecomManager) context.getSystemService(context.TELECOM_SERVICE);
+        PhoneAccount phoneAccount = telecomManager.getPhoneAccount(request.getAccountHandle());
+
+        if((phoneAccount.getCapabilities() & PhoneAccount.CAPABILITY_SELF_MANAGED) == PhoneAccount.CAPABILITY_SELF_MANAGED) {
+            connection.setConnectionProperties(Connection.PROPERTY_SELF_MANAGED);
+        }
+
         connection.setInitializing();
         connection.setExtras(extras);
         currentConnections.put(extras.getString(EXTRA_CALL_UUID), connection);


### PR DESCRIPTION
ok

on android we didnt use callkeep, as there was no need for it plus the calling screen appeared upon startCall(), it was requiring permissions for calling accounts upon setup() call etc ...

however, on android, when in room and phone went to sleep, it was terminated after couple of minutes ...

callkeep 'keeps' the call alive by hooking into TelecomManager

1. removed permissions from callkeep manifest, as we dont need those and they show up in apps permissions list
2. removed permissions from array of permissions in RnCalKeepModule as those are used for permission runtime checks and we dont need them (we only need RECORD_AUDIO and we check for that when the call starts)
3. we are now using custom self-managed phone account for around call , which means that the default native dialer doesnt show up and it is not added into list of calling accounts on phone, which results in very awk experience for user
4. commented out the body from onCallAudioStateChanged() as it was causing issues when switching audio-out in incall-manager (more to that below)
5. setting the connection on our self-manager phone account to be self-managed as well

with the changes above i was able to start meet, put phone to sleep and meet was running fine ... however, i was no longer able to change the audio-out, for which we use rn-incall-manager

- problem is, that incall-manager obtains audio context that is used for switching, however the rncallkeep "steals" it with the call to native ` telecomManager.placeCall()` ... when this happens, incall-manager is no longer able to perform any audio switching ...

sooooo, after lots of messing with this crap, debugging and studying, the solution will be as follows ...
- for android, when entering meet, we will only call incall-manager , so the audio-out switcher works, incall-manager has the context ... 
- when android app is backgrounded and in room, we will call callkeeps startCall ... this means, that the call will 'persist' even with device in sleep mode ... this steals audio focus from incall-manager, but it doesnt matter, as user is not interacting with the app, when it is backgrounded of course ... upon app coming back to foreground, we call callkeeps endCall, which releases audio context back for incall manager and it can again use it for audio switching
- this way we have android working when in room and phone sleeping and also audio selection works ...